### PR TITLE
Add manually curated contributors and add link to universe

### DIFF
--- a/content/contact.md
+++ b/content/contact.md
@@ -4,7 +4,7 @@ draft: false
 images: []
 menu: main
 title: Contact
-weight: 3
+weight: 4
 ---
 
 ## The RforMassSpectrometry initiative

--- a/content/contributions.md
+++ b/content/contributions.md
@@ -1,0 +1,44 @@
+---
+description: ""
+draft: false
+images: []
+menu: main
+title: Contributors
+weight: 3
+---
+
+## Contributors
+
+This page lists contributors (in alphabetical order) to the various
+packages. This list was manually curated and might thus not be complete. For
+individual code contributions to the packages see
+[here](https://rformassspectrometry.r-universe.dev/ui#contributors). For more
+information on how to become a contributor yourself see the contribution section
+in the [main page](https://www.rformassspectrometry.org/).
+
+- [Josep M. Badia](https://github.com/jmbadia) (`CompoundDb`, `MsCoreUtils`)
+- [Thomas Burger]() (`PSMatch`)
+- [Laurent Gatto](https://github.com/lgatto) (`Spectra`, `PSMatch`,
+  `MsCoreUtils`, `QFeatures`, `MsExperiment`, `MsBackendMgf`, `SpectraVis`,
+  `MsQuantitation`)
+- [Sebastian Gibb](https://github.com/sgibb) (`MetaboCoreUtils`, `Spectra`,
+  `PSMatch`, `MsCoreUtils`, `SpectraQL`, `MsExperiment`, `MsBackendMgf`)
+- [Thomas Naake](https://github.com/tnaake) (`MsCoreUtils`)
+- [Steffen Neumann](https://github.com/sneumann) (`MsBackendTimsTof`,
+  `MsBackendMsp`)
+- [Johannes Rainer](https://github.com/jorainer) (`MsBackendTimsTof`,
+  `MetaboAnnotation`, `MetaboCoreUtils`, `Spectra`, `PSMatch`, `CompoundDb`,
+  `MsBackendMsp`, `MsCoreUtils`, `SpectraQL`, `MsExperiment`, `MsFeatures`,
+  `MsBackendMassbank`, `MsBackendMgf`)
+- [Liesa Salzer](https://github.com/LiesaSalzer) (`MetaboCoreUtils`)
+- [Sigurdur Smarason](https://github.com/SiggiSmara) (`MsCoreUtils`)
+- [Jan Stanstrup](https://github.com/stanstrup) (`Spectra`, `CompoundDb`)
+- [Adriaan Sticker]() (`MsCoreUtils`)
+- [Michael Stravs](https://github.com/meowcat/) (`MetaboCoreUtils`,
+  `MsBackendMassbank`)
+- [Christophe Vanderaa](https://github.com/cvanderaa) (`QFeatures`)
+- [Andrea Vicini](https://github.com/andreavicini) (`MsBackendTimsTof`,
+  `MetaboAnnotation`, `MetaboCoreUtils`, `CompoundDb`, `SpectraQL`)
+- [Samuel Wieczorek](https://github.com/samWieczorek) (`PSMatch`, `MsCoreUtils`)
+- [Michael Witting](https://github.com/michaelwitting/) (`MetaboAnnotation`,
+  `MetaboCoreUtils`, `MsBackendMsp`, `MsCoreUtils`, `MsBackendMassbank`)

--- a/content/pkgs.md
+++ b/content/pkgs.md
@@ -7,6 +7,11 @@ title: Packages
 weight: 2
 ---
 
+This page lists some core packages from *RforMassSpectrometry*. For a full
+listing of currently available package see the project's [R universe
+page](https://rformassspectrometry.r-universe.dev/ui#packages).
+
+
 ## Installation and use
 
 Execute


### PR DESCRIPTION
This PR:
- adds a manually curated list of contributors (some of them don't show up on the R universe page bacause the contributions were to the original package such as `MSnbase`).
- adds a link to the R universe page.