### PR TITLE
Adding a documentation tab

### DIFF
--- a/content/contributions.md
+++ b/content/contributions.md
@@ -28,7 +28,7 @@ in the [main page](https://www.rformassspectrometry.org/).
 - [Helge Hecht](https://github.com/hechth) (`SpectriPy`)
 - [Carolin Huber](https://github.com/chufz) (`MetaboAnnotation`, `SpectriPy`)
 - [Philippine Louail](https://github.com/philouail) (`MetaboCoreUtils`,
-  `MetaboAnnotation`)
+  `MetaboAnnotation`, `MsCoreUtils`, `Spectra`)
 - [Thomas Naake](https://github.com/tnaake) (`MsCoreUtils`)
 - [Steffen Neumann](https://github.com/sneumann) (`MsBackendTimsTof`,
   `MsBackendMsp`)

--- a/content/contributions.md
+++ b/content/contributions.md
@@ -18,7 +18,7 @@ in the [main page](https://www.rformassspectrometry.org/).
 
 - [Josep M. Badia](https://github.com/jmbadia) (`CompoundDb`, `MsCoreUtils`)
 - [Roger Giné Bertomeu](https://github.com/RogerGinBer) (`CompoundDb`,
-  `MetaboCoreUtils`, `MsCoreUtils`)
+  `MetaboCoreUtils`, `MsCoreUtils`, `MsBackendTimsTof`)
 - [Mar Garcia-Aloy](https://github.com/mar-garcia) (`MsCoreUtils`)
 - [Laurent Gatto](https://github.com/lgatto) (`Spectra`, `PSMatch`,
   `MsCoreUtils`, `QFeatures`, `MsExperiment`, `MsBackendMgf`, `SpectraVis`,
@@ -26,7 +26,8 @@ in the [main page](https://www.rformassspectrometry.org/).
 - [Sebastian Gibb](https://github.com/sgibb) (`MetaboCoreUtils`, `Spectra`,
   `PSMatch`, `MsCoreUtils`, `SpectraQL`, `MsExperiment`, `MsBackendMgf`)
 - [Helge Hecht](https://github.com/hechth) (`SpectriPy`)
-- [Carolin Huber](https://github.com/chufz) (`MetaboAnnotation`, `SpectriPy`)
+- [Carolin Huber](https://github.com/chufz) (`MetaboAnnotation`, `SpectriPy`,
+  `MsBackendTimsTof`)
 - [Philippine Louail](https://github.com/philouail) (`MetaboCoreUtils`,
   `MetaboAnnotation`, `MsCoreUtils`, `Spectra`)
 - [Thomas Naake](https://github.com/tnaake) (`MsCoreUtils`)

--- a/content/documentation.md
+++ b/content/documentation.md
@@ -1,0 +1,49 @@
+---
+description: ""
+draft: false
+images: []
+menu: main
+title: Documentation
+weight: 3
+---
+
+## Documentation
+
+Ample documentation is provided within each individual package. All package
+vignettes are also available  Each package provides specific documentation.
+
+In addition, a comprehensive book as well as tutorials and workshops are
+available showing how the functionality from different packages can be combined
+into specific analysis workflows.
+
+
+### R for Mass Spectrometry Book
+
+The [R for Mass Spectrometry book](https://rformassspectrometry.github.io/book/)
+provides a good introduction into the ecosystem of the R for Mass Spectrometry
+packages. It is continuously expanded to include additional topics and example
+use cases.
+
+
+### Tutorials/workshops
+
+Specific use cases and extended analysis workflows are also presented as
+workshops (tutorials). They usually come with a dedicated
+[docker](https://www.docker.com) image that provides the workshop's source code
+along with all data and an R installation which includes all required packages
+ensuring full reproducibility.
+
+- [SpectraTutorials](https://jorainer.github.io/SpectraTutorials): provides 3
+  tutorials explaining internals, properties and extensions of the
+  [Spectra](https://github.com/RforMassSpectrometry/Spectra) package and the
+  provided infrastructure to handle and process mass spectrometry data.
+- [xcmsTutorials](https://jorainer.github.io/xcmsTutorials): explains general
+  mass spectrometry data handling with
+  [Spectra](https://github.com/RforMassSpectrometry/Spectra) and analysis of
+  LC-MS data with the [xcms](https://github.com/sneumann/xcms) package.
+- [MetaboAnnotationTutorials](https://jorainer.github.io/MetaboAnnotationTutorials):
+  use cases and examples for annotation of untargeted metabolomics data using
+  the
+  [MetaboAnnotation](https://github.com/RforMassSpectrometry/MetaboAnnotation)
+  package.
+


### PR DESCRIPTION
This PR adds a documentation page where we could list all books, workshops etc in a single place. I just added a documentation.md but did not link/add this page somewhere in the index (since I was not sure where I should do that...)?